### PR TITLE
POLY-860 [ProxyMorph] Monter l'environnement local Laravel/ProxyMorph

### DIFF
--- a/builds/docker/Node22-alpine/Dockerfile
+++ b/builds/docker/Node22-alpine/Dockerfile
@@ -1,0 +1,53 @@
+# Définir des arguments de build pour l'architecture et le système d'exploitation cibles
+ARG TARGETOS
+ARG TARGETARCH
+
+# Utiliser l'image Node 22 Alpine officielle comme base
+FROM --platform=$BUILDPLATFORM node:22-alpine
+
+# Label de mainteneur
+LABEL maintainer="Dotworld"
+
+# Arguments de build
+ARG NODE_VERSION=22
+
+# Définir le répertoire de travail
+WORKDIR /var/www/html
+
+# Variables d'environnement
+ENV TZ=Europe/Paris
+ENV NVM_DIR=/usr/local/nvm
+ENV NODE_VERSION=$NODE_VERSION
+
+# Installer les outils nécessaires (équivalents Alpine)
+RUN apk update && apk upgrade && \
+    apk add --no-cache \
+    bash \
+    curl \
+    nano \
+    figlet \
+    docker-cli \
+    git \
+    openssh-client \
+    make \
+    cmake \
+    pkgconfig \
+    python3 \
+    build-base && \
+    # Configurer le fuseau horaire
+    ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    # Activer corepack et préparer yarn
+    corepack enable && \
+    corepack prepare yarn@1.22 --activate && \
+    yarn --version
+
+# Nettoyage
+RUN rm -rf /var/cache/apk/* /root/.npm /root/.yarn
+
+# Copier le script de démarrage et définir les permissions
+COPY start-container /usr/local/bin/start-container
+RUN chmod +x /usr/local/bin/start-container
+
+# Point d'entrée du conteneur
+ENTRYPOINT ["start-container"]
+

--- a/builds/docker/Node22-alpine/start-container
+++ b/builds/docker/Node22-alpine/start-container
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+chmod 666 /var/run/docker.sock || true
+
+while true; do
+    sleep 1
+done
+

--- a/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --no-cache \
         oniguruma-dev \
         librsvg \
         sqlite \
+        oniguruma oniguruma-dev \
     && install-php-extensions \
         pdo_mysql \
         gd \

--- a/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
@@ -17,7 +17,8 @@ RUN apk add --no-cache \
         oniguruma-dev \
         librsvg \
         sqlite \
-        oniguruma oniguruma-dev \
+        oniguruma \
+        oniguruma-dev \
     && install-php-extensions \
         pdo_mysql \
         gd \

--- a/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
@@ -35,7 +35,8 @@ RUN apk add --no-cache \
         msgpack \
         imagick \
         mbstring \
-        sqlite3
+        sqlite3 \
+        pcntl
 
 RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
 

--- a/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp-alpine/Dockerfile
@@ -1,0 +1,75 @@
+ARG TARGETOS
+ARG TARGETARCH
+
+# Builder on Alpine to keep runtime small
+FROM --platform=$BUILDPLATFORM dunglas/frankenphp:php8.4-alpine AS frankenphp
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apk add --no-cache \
+        git \
+        unzip \
+        icu-dev \
+        libzip-dev \
+        libpng-dev \
+        libjpeg-turbo-dev \
+        freetype-dev \
+        oniguruma-dev \
+        librsvg \
+        sqlite \
+    && install-php-extensions \
+        pdo_mysql \
+        gd \
+        intl \
+        zip \
+        opcache \
+        imap \
+        ldap \
+        pcov \
+        redis \
+        swoole \
+        memcached \
+        igbinary \
+        msgpack \
+        imagick \
+        mbstring \
+        sqlite3
+
+RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
+
+WORKDIR /app/public
+RUN mkdir -p /var/www && ln -s /app/public /var/www/html
+
+# Final Alpine runtime with Node 22 (custom base)
+FROM --platform=$BUILDPLATFORM chdotworld/dotworld:node22-alpine
+
+LABEL maintainer="Thibaud WILLM <thibaud.willm@dotworld.ch>"
+
+ARG WWWGROUP=1000
+
+WORKDIR /app/public
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy FrankenPHP runtime, PHP, composer and extensions from builder
+COPY --from=frankenphp /usr/local/ /usr/local/
+COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
+
+# Minimal runtime deps and permissions
+RUN apk add --no-cache \
+        libcap \
+        librsvg \
+        sqlite \
+    && mkdir -p /config/caddy /data/caddy \
+    && mkdir -p /var/www && ln -s /app/public /var/www/html || true \
+    && setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp || true
+
+COPY start-container /usr/local/bin/start-container
+COPY php.ini /usr/local/etc/php/conf.d/99-vscode.ini
+
+RUN chmod +x /usr/local/bin/start-container
+
+EXPOSE 80 443 443/udp
+
+ENTRYPOINT ["start-container"]
+

--- a/builds/docker/Php8.4-frankenphp-alpine/php.ini
+++ b/builds/docker/Php8.4-frankenphp-alpine/php.ini
@@ -1,0 +1,13 @@
+[PHP]
+post_max_size = 100M
+upload_max_filesize = 100M
+variables_order = EGPCS
+
+[opcache]
+opcache.enable_cli=1
+
+[pcov]
+pcov.enabled = 1
+pcov.directory = .
+pcov.exclude = "~vendor~"
+

--- a/builds/docker/Php8.4-frankenphp-alpine/start-container
+++ b/builds/docker/Php8.4-frankenphp-alpine/start-container
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ ! -d /.composer ]; then
+    mkdir /.composer
+fi
+
+chmod -R ugo+rw /.composer || true
+
+: "${SERVER_NAME:=localhost, :80, :443}"
+
+exec frankenphp run --server-name "$SERVER_NAME"
+

--- a/builds/docker/Php8.4-frankenphp-alpine/start-container
+++ b/builds/docker/Php8.4-frankenphp-alpine/start-container
@@ -1,13 +1,22 @@
-#!/usr/bin/env sh
-set -eu
+#!/usr/bin/env bash
 
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi
 
-chmod -R ugo+rw /.composer || true
+chmod -R ugo+rw /.composer
 
-: "${SERVER_NAME:=localhost, :80, :443}"
+chmod 666 /var/run/docker.sock 2>/dev/null || true
 
-exec frankenphp run --server-name "$SERVER_NAME"
+# Create Caddy config and data directories if they don't exist
+mkdir -p /config/caddy /data/caddy 2>/dev/null || true
 
+# Set default SERVER_NAME for FrankenPHP if not provided
+export SERVER_NAME="${SERVER_NAME:-localhost, :80, :443}"
+
+# Keep container running for devcontainer usage
+# Laravel Octane with FrankenPHP can be started manually with:
+# php artisan octane:start --server=frankenphp
+while true; do
+    sleep 1
+done

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -54,6 +54,8 @@ RUN apt-get update \
         librsvg2-bin \
         mysql-client \
         ca-certificates \
+        libonig5 \
+        libonig-dev \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -47,11 +47,23 @@ COPY --from=frankenphp /usr/local/ /usr/local/
 COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
 
 # Ensure expected folders and minimal tools, grant net bind capability
+# Install required shared libraries for PHP extensions copied from FrankenPHP
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libcap2-bin \
         sqlite3 \
         librsvg2-bin \
+        libonig5 \
+        libzip4 \
+        libpng16-16 \
+        libjpeg62-turbo \
+        libwebp7 \
+        libfreetype6 \
+        libicu72 \
+        libldap-2.5-0 \
+        libmagickwand-6.q16-6 \
+        libmemcached11 \
+        libc-client2007e \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /config/caddy /data/caddy \
     && mkdir -p /var/www && ln -s /app/public /var/www/html || true \

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -1,80 +1,74 @@
 ARG TARGETOS
 ARG TARGETARCH
 
-# Builder stage: prepare FrankenPHP, PHP runtime and extensions
+# Builder stage: FrankenPHP with PHP 8.4 and extensions
 FROM --platform=$BUILDPLATFORM dunglas/frankenphp:php8.4-bookworm AS frankenphp
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
-    && install-php-extensions \
-        pdo_mysql \
-        gd \
-        intl \
-        zip \
-        opcache \
-        imap \
-        ldap \
-        pcov \
-        redis \
-        swoole \
-        memcached \
-        igbinary \
-        msgpack \
-        imagick \
-        mbstring \
-        sqlite3 \
-    && rm -rf /var/lib/apt/lists/*
+# Install PHP extensions required for Laravel Octane
+RUN install-php-extensions \
+    pdo_mysql \
+    pdo_sqlite \
+    gd \
+    intl \
+    zip \
+    opcache \
+    imap \
+    ldap \
+    pcov \
+    redis \
+    swoole \
+    memcached \
+    igbinary \
+    msgpack \
+    imagick \
+    mbstring \
+    sqlite3 \
+    curl \
+    xml \
+    bcmath \
+    soap \
+    readline
 
+# Install Composer
 RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
 
-WORKDIR /app/public
-RUN mkdir -p /var/www && ln -s /app/public /var/www/html
-
-# Final stage: your Node 22 Ubuntu base image with FrankenPHP runtime
+# Final stage: Node 22 Ubuntu base image with FrankenPHP runtime
 FROM --platform=$BUILDPLATFORM chdotworld/dotworld:node22-ubuntu
 
 LABEL maintainer="Thibaud WILLM <thibaud.willm@dotworld.ch>"
 
 ARG WWWGROUP=1000
 
-WORKDIR /app/public
+WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Copy FrankenPHP runtime, PHP, composer and extensions from builder
+# Install minimal runtime dependencies
+# FrankenPHP and PHP from the builder already include most dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        sqlite3 \
+        libcap2-bin \
+        librsvg2-bin \
+        mysql-client \
+        ca-certificates \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy FrankenPHP runtime, PHP, Composer and all extensions from builder
+COPY --from=frankenphp /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 COPY --from=frankenphp /usr/local/ /usr/local/
 COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
 
-# Install essential system libraries required by FrankenPHP and PHP extensions
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libcap2-bin \
-        sqlite3 \
-        librsvg2-bin \
-        libonig5 \
-    && (apt-get install -y --no-install-recommends \
-        libzip4 \
-        libpng16-16 \
-        libjpeg-turbo8 \
-        libwebp7 \
-        libfreetype6 \
-        libicu70 \
-        libldap-2.5-0 \
-        libmagickwand-6.q16-6 \
-        libmagickcore-6.q16-6 \
-        libmemcached11 \
-        libc-client2007e \
-        libsasl2-2 \
-        libgssapi-krb5-2 \
-    || echo "Some optional packages could not be installed, continuing...") \
-    && ldconfig \
-    && echo "Verifying critical libraries are available:" \
-    && ldconfig -p | grep -E "libonig|libzip|libcap" || echo "Some libraries missing but continuing..." \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /config/caddy /data/caddy \
-    && mkdir -p /var/www && ln -s /app/public /var/www/html || true \
-    && setcap "cap_net_bind_service=+ep" /usr/local/bin/frankenphp || true
+# Set proper permissions for FrankenPHP to bind to privileged ports
+RUN setcap "cap_net_bind_service=+ep" /usr/local/bin/frankenphp
+
+# Create necessary directories
+RUN mkdir -p /config/caddy /data/caddy /.composer \
+    && chmod -R ugo+rw /.composer
 
 COPY start-container /usr/local/bin/start-container
 COPY php.ini /usr/local/etc/php/conf.d/99-vscode.ini

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
         imagick \
         mbstring \
         sqlite3 \
+        oniguruma oniguruma-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -82,17 +82,17 @@ COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
 
 # Copy critical Debian libraries from FrankenPHP image for PHP extensions compatibility
 # These specific library versions are required by gd, intl, swoole, and other extensions
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libc-client.so.2007e /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicuio.so.72 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicui18n.so.72 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicuuc.so.72 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicudata.so.72 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libsodium.so.23 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libpq.so.5 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libmemcached.so.11 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libzip.so.4 /usr/lib/x86_64-linux-gnu/
-COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libavif.so.* /usr/lib/x86_64-linux-gnu/
+# Note: Using wildcards to support both x86_64 and aarch64 architectures
+COPY --from=frankenphp /usr/lib/*/libgomp.so.1 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libc-client.so.2007e /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libicuio.so.72 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libicui18n.so.72 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libicuuc.so.72 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libicudata.so.72 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libsodium.so.23 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libpq.so.5 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libmemcached.so.11 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libzip.so.4 /usr/local/lib/
 
 # Set proper permissions for FrankenPHP to bind to privileged ports and update library cache
 RUN setcap "cap_net_bind_service=+ep" /usr/local/bin/frankenphp \

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -72,6 +72,8 @@ RUN apt-get update \
         libssl3 \
         libxml2 \
         libxslt1.1 \
+        libxpm4 \
+        libx11-6 \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -109,6 +111,7 @@ COPY --from=frankenphp /usr/lib/*/libzip.so.4 /usr/local/lib/
 # Image processing (GD)
 COPY --from=frankenphp /usr/lib/*/libavif.so.15 /usr/local/lib/
 COPY --from=frankenphp /usr/lib/*/libjpeg.so.62 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libXpm.so.4 /usr/local/lib/
 
 # Memcached dependencies
 COPY --from=frankenphp /usr/lib/*/libmemcached.so.11 /usr/local/lib/

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -46,24 +46,31 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY --from=frankenphp /usr/local/ /usr/local/
 COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
 
-# Ensure expected folders and minimal tools, grant net bind capability
-# Install required shared libraries for PHP extensions copied from FrankenPHP
+# Install essential system libraries required by FrankenPHP and PHP extensions
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libcap2-bin \
         sqlite3 \
         librsvg2-bin \
         libonig5 \
+    && (apt-get install -y --no-install-recommends \
         libzip4 \
         libpng16-16 \
-        libjpeg62-turbo \
+        libjpeg-turbo8 \
         libwebp7 \
         libfreetype6 \
-        libicu72 \
+        libicu70 \
         libldap-2.5-0 \
         libmagickwand-6.q16-6 \
+        libmagickcore-6.q16-6 \
         libmemcached11 \
         libc-client2007e \
+        libsasl2-2 \
+        libgssapi-krb5-2 \
+    || echo "Some optional packages could not be installed, continuing...") \
+    && ldconfig \
+    && echo "Verifying critical libraries are available:" \
+    && ldconfig -p | grep -E "libonig|libzip|libcap" || echo "Some libraries missing but continuing..." \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /config/caddy /data/caddy \
     && mkdir -p /var/www && ln -s /app/public /var/www/html || true \

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -45,8 +45,8 @@ WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Install minimal runtime dependencies
-# FrankenPHP and PHP from the builder already include most dependencies
+# Install runtime dependencies for PHP extensions
+# These libraries are needed for the extensions copied from the Debian-based FrankenPHP image
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         sqlite3 \
@@ -55,7 +55,23 @@ RUN apt-get update \
         mysql-client \
         ca-certificates \
         libonig5 \
-        libonig-dev \
+        libzip4 \
+        libpng16-16 \
+        libjpeg-turbo8 \
+        libwebp7 \
+        libavif15 \
+        libfreetype6 \
+        libgomp1 \
+        libmagickwand-6.q16-6 \
+        libmagickcore-6.q16-6 \
+        libc-client2007e \
+        libicu70 \
+        libsodium23 \
+        libpq5 \
+        libmemcached11 \
+        libssl3 \
+        libxml2 \
+        libxslt1.1 \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -29,7 +29,8 @@ RUN install-php-extensions \
     xml \
     bcmath \
     soap \
-    readline
+    readline \
+    pcntl
 
 # Install Composer
 RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
@@ -107,6 +108,7 @@ COPY --from=frankenphp /usr/lib/*/libzip.so.4 /usr/local/lib/
 
 # Image processing (GD)
 COPY --from=frankenphp /usr/lib/*/libavif.so.15 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libjpeg.so.62 /usr/local/lib/
 
 # Memcached dependencies
 COPY --from=frankenphp /usr/lib/*/libmemcached.so.11 /usr/local/lib/

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -80,8 +80,23 @@ COPY --from=frankenphp /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 COPY --from=frankenphp /usr/local/ /usr/local/
 COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
 
-# Set proper permissions for FrankenPHP to bind to privileged ports
-RUN setcap "cap_net_bind_service=+ep" /usr/local/bin/frankenphp
+# Copy critical Debian libraries from FrankenPHP image for PHP extensions compatibility
+# These specific library versions are required by gd, intl, swoole, and other extensions
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libc-client.so.2007e /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicuio.so.72 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicui18n.so.72 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicuuc.so.72 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libicudata.so.72 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libsodium.so.23 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libpq.so.5 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libmemcached.so.11 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libzip.so.4 /usr/lib/x86_64-linux-gnu/
+COPY --from=frankenphp /usr/lib/x86_64-linux-gnu/libavif.so.* /usr/lib/x86_64-linux-gnu/
+
+# Set proper permissions for FrankenPHP to bind to privileged ports and update library cache
+RUN setcap "cap_net_bind_service=+ep" /usr/local/bin/frankenphp \
+    && ldconfig
 
 # Create necessary directories
 RUN mkdir -p /config/caddy /data/caddy /.composer \

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update \
         libpng16-16 \
         libjpeg-turbo8 \
         libwebp7 \
-        libavif15 \
         libfreetype6 \
         libgomp1 \
         libmagickwand-6.q16-6 \

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -1,0 +1,72 @@
+ARG TARGETOS
+ARG TARGETARCH
+
+# Builder stage: prepare FrankenPHP, PHP runtime and extensions
+FROM --platform=$BUILDPLATFORM dunglas/frankenphp:php8.4-bookworm AS frankenphp
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && install-php-extensions \
+        pdo_mysql \
+        gd \
+        intl \
+        zip \
+        opcache \
+        imap \
+        ldap \
+        pcov \
+        redis \
+        swoole \
+        memcached \
+        igbinary \
+        msgpack \
+        imagick \
+        mbstring \
+        sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
+
+WORKDIR /app/public
+RUN mkdir -p /var/www && ln -s /app/public /var/www/html
+
+# Final stage: your Node 22 Ubuntu base image with FrankenPHP runtime
+FROM --platform=$BUILDPLATFORM chdotworld/dotworld:node22-ubuntu
+
+LABEL maintainer="Thibaud WILLM <thibaud.willm@dotworld.ch>"
+
+ARG WWWGROUP=1000
+
+WORKDIR /app/public
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Copy FrankenPHP runtime, PHP, composer and extensions from builder
+COPY --from=frankenphp /usr/local/ /usr/local/
+COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
+
+# Ensure expected folders and minimal tools, grant net bind capability
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libcap2-bin \
+        sqlite3 \
+        librsvg2-bin \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /config/caddy /data/caddy \
+    && mkdir -p /var/www && ln -s /app/public /var/www/html || true \
+    && setcap "cap_net_bind_service=+ep" /usr/local/bin/frankenphp || true
+
+COPY start-container /usr/local/bin/start-container
+COPY php.ini /usr/local/etc/php/conf.d/99-vscode.ini
+
+RUN chmod +x /usr/local/bin/start-container
+
+COPY vscode-nopasswd /etc/sudoers.d/vscode
+
+RUN chmod 440 /etc/sudoers.d/vscode
+
+EXPOSE 80 443 443/udp
+
+ENTRYPOINT ["start-container"]
+

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -81,18 +81,39 @@ COPY --from=frankenphp /usr/local/ /usr/local/
 COPY --from=frankenphp /usr/bin/composer /usr/bin/composer
 
 # Copy critical Debian libraries from FrankenPHP image for PHP extensions compatibility
-# These specific library versions are required by gd, intl, swoole, and other extensions
+# These specific library versions are required by gd, intl, swoole, memcached and other extensions
 # Note: Using wildcards to support both x86_64 and aarch64 architectures
+
+# Core libraries
 COPY --from=frankenphp /usr/lib/*/libgomp.so.1 /usr/local/lib/
-COPY --from=frankenphp /usr/lib/*/libc-client.so.2007e /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libgdbm.so.6 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libgdbm_compat.so.4 /usr/local/lib/
+
+# ICU libraries (for intl extension)
 COPY --from=frankenphp /usr/lib/*/libicuio.so.72 /usr/local/lib/
 COPY --from=frankenphp /usr/lib/*/libicui18n.so.72 /usr/local/lib/
 COPY --from=frankenphp /usr/lib/*/libicuuc.so.72 /usr/local/lib/
 COPY --from=frankenphp /usr/lib/*/libicudata.so.72 /usr/local/lib/
+
+# Cryptography and security
 COPY --from=frankenphp /usr/lib/*/libsodium.so.23 /usr/local/lib/
+
+# Database clients
 COPY --from=frankenphp /usr/lib/*/libpq.so.5 /usr/local/lib/
-COPY --from=frankenphp /usr/lib/*/libmemcached.so.11 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libc-client.so.2007e /usr/local/lib/
+
+# Compression and archives
 COPY --from=frankenphp /usr/lib/*/libzip.so.4 /usr/local/lib/
+
+# Image processing (GD)
+COPY --from=frankenphp /usr/lib/*/libavif.so.15 /usr/local/lib/
+
+# Memcached dependencies
+COPY --from=frankenphp /usr/lib/*/libmemcached.so.11 /usr/local/lib/
+COPY --from=frankenphp /usr/lib/*/libhashkit.so.2 /usr/local/lib/
+
+# Swoole dependencies (async networking)
+COPY --from=frankenphp /usr/lib/*/libcares.so.2 /usr/local/lib/
 
 # Set proper permissions for FrankenPHP to bind to privileged ports and update library cache
 RUN setcap "cap_net_bind_service=+ep" /usr/local/bin/frankenphp \

--- a/builds/docker/Php8.4-frankenphp/Dockerfile
+++ b/builds/docker/Php8.4-frankenphp/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update \
         imagick \
         mbstring \
         sqlite3 \
-        oniguruma oniguruma-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/builds/docker/Php8.4-frankenphp/php.ini
+++ b/builds/docker/Php8.4-frankenphp/php.ini
@@ -1,0 +1,13 @@
+[PHP]
+post_max_size = 100M
+upload_max_filesize = 100M
+variables_order = EGPCS
+
+[opcache]
+opcache.enable_cli=1
+
+[pcov]
+pcov.enabled = 1
+pcov.directory = .
+pcov.exclude = "~vendor~"
+

--- a/builds/docker/Php8.4-frankenphp/start-container
+++ b/builds/docker/Php8.4-frankenphp/start-container
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi
 
-chmod -R ugo+rw /.composer || true
+chmod -R ugo+rw /.composer
 
-# Allow binding to privileged ports when run as non-root (if capability is set)
-setcap -v cap_net_bind_service+ep /usr/local/bin/frankenphp || true
+chmod 666 /var/run/docker.sock 2>/dev/null || true
 
-# Default SERVER_NAME: hostname and bind on :80 and :443 (HTTP/3 enabled by image)
-: "${SERVER_NAME:=localhost, :80, :443}"
+# Create Caddy config and data directories if they don't exist
+mkdir -p /config/caddy /data/caddy 2>/dev/null || true
 
-exec frankenphp run
+# Set default SERVER_NAME for FrankenPHP if not provided
+export SERVER_NAME="${SERVER_NAME:-localhost, :80, :443}"
+
+# Keep container running for devcontainer usage
+# Laravel Octane with FrankenPHP can be started manually with:
+# php artisan octane:start --server=frankenphp
+while true; do
+    sleep 1
+done

--- a/builds/docker/Php8.4-frankenphp/start-container
+++ b/builds/docker/Php8.4-frankenphp/start-container
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ ! -d /.composer ]; then
+    mkdir /.composer
+fi
+
+chmod -R ugo+rw /.composer || true
+
+# Allow binding to privileged ports when run as non-root (if capability is set)
+setcap -v cap_net_bind_service+ep /usr/local/bin/frankenphp || true
+
+# Default SERVER_NAME: hostname and bind on :80 and :443 (HTTP/3 enabled by image)
+: "${SERVER_NAME:=localhost, :80, :443}"
+
+exec frankenphp run --server-name "$SERVER_NAME"
+

--- a/builds/docker/Php8.4-frankenphp/start-container
+++ b/builds/docker/Php8.4-frankenphp/start-container
@@ -14,5 +14,4 @@ setcap -v cap_net_bind_service+ep /usr/local/bin/frankenphp || true
 # Default SERVER_NAME: hostname and bind on :80 and :443 (HTTP/3 enabled by image)
 : "${SERVER_NAME:=localhost, :80, :443}"
 
-exec frankenphp run --server-name "$SERVER_NAME"
-
+exec frankenphp run

--- a/builds/docker/Php8.4-frankenphp/vscode-nopasswd
+++ b/builds/docker/Php8.4-frankenphp/vscode-nopasswd
@@ -1,0 +1,1 @@
+vscode ALL=(ALL) NOPASSWD: ALL

--- a/stubs/stacks/Stack-php84-frankenphp/README.md
+++ b/stubs/stacks/Stack-php84-frankenphp/README.md
@@ -1,0 +1,169 @@
+# Stack PHP 8.4 avec FrankenPHP pour Laravel Octane
+
+Cette stack est optimisée pour développer des applications Laravel avec **Laravel Octane** et **FrankenPHP**.
+
+## 🚀 Qu'est-ce que FrankenPHP ?
+
+FrankenPHP est un serveur d'application PHP moderne écrit en Go qui offre :
+- **Performance ultra-rapide** avec mode worker
+- Support **HTTP/2** et **HTTP/3**
+- Support natif de **Laravel Octane**
+- Compression Brotli et Zstandard
+- Certificats HTTPS automatiques
+- Worker mode pour garder votre application en mémoire
+
+## 📦 Contenu de la stack
+
+- **PHP 8.4** avec toutes les extensions nécessaires
+- **FrankenPHP** pour servir votre application
+- **Node.js 22** pour le build frontend
+- **MySQL 8.0** pour la base de données
+- **Redis** pour le cache et les sessions
+- **Composer** pour les dépendances PHP
+
+## 🛠️ Extensions PHP installées
+
+Toutes les extensions requises pour Laravel sont pré-installées :
+- pdo_mysql, pdo_sqlite
+- gd, imagick
+- intl, mbstring
+- zip, xml
+- opcache (activé en CLI)
+- redis, memcached
+- swoole (pour Octane)
+- pcov (pour les tests de couverture)
+- curl, soap, bcmath, readline, ldap
+
+## 🎯 Commandes disponibles
+
+### Initialisation du projet
+```bash
+# Initialise le projet complet (composer, npm, migrations, etc.)
+install
+```
+
+### Démarrage du serveur
+
+```bash
+# Méthode 1 : Commande complète
+php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=80
+
+# Méthode 2 : Commande custom
+serve
+
+# Méthode 3 : Commande octane avec auto-reload
+octane --watch
+
+# Méthode 4 : Alias
+octane          # Lance Octane
+octane-watch    # Lance Octane en mode watch
+```
+
+### Autres commandes
+```bash
+artisan         # Lance artisan de manière interactive
+run             # Lance la compilation frontend (npm run watch)
+xdebug          # Installe et configure Xdebug
+```
+
+## 📝 Configuration Laravel Octane
+
+### Installation d'Octane dans un projet existant
+
+```bash
+composer require laravel/octane
+php artisan octane:install --server=frankenphp
+```
+
+### Configuration recommandée
+
+Dans votre fichier `config/octane.php` :
+
+```php
+return [
+    'server' => env('OCTANE_SERVER', 'frankenphp'),
+    
+    'frankenphp' => [
+        'host' => env('OCTANE_HOST', '0.0.0.0'),
+        'port' => env('OCTANE_PORT', 80),
+        'workers' => env('OCTANE_WORKERS', 4),
+        'max_requests' => env('OCTANE_MAX_REQUESTS', 500),
+    ],
+    
+    'watch' => [
+        'app',
+        'bootstrap',
+        'config',
+        'database',
+        'resources/**/*.php',
+        'routes',
+    ],
+];
+```
+
+### Variables d'environnement
+
+Ajoutez dans votre `.env` :
+
+```env
+OCTANE_SERVER=frankenphp
+OCTANE_HOST=0.0.0.0
+OCTANE_PORT=80
+OCTANE_WORKERS=4
+OCTANE_MAX_REQUESTS=500
+```
+
+## ⚡ Performance
+
+Avec FrankenPHP et Laravel Octane, vous obtiendrez :
+- **2-3x plus rapide** que PHP-FPM traditionnel
+- Application gardée en mémoire entre les requêtes
+- Temps de réponse réduits de manière significative
+
+## 🐛 Debug avec Xdebug
+
+Pour installer et configurer Xdebug :
+
+```bash
+xdebug
+```
+
+La configuration est automatiquement ajoutée avec :
+- Port : 9003
+- IDE Key : dotworld
+- Host : host.docker.internal
+
+## 📌 Ports exposés
+
+- **80** : HTTP
+- **443** : HTTPS
+- **6001** : WebSockets
+- **3306** : MySQL
+- **6379** : Redis
+
+## ⚠️ Important à savoir
+
+### Variables globales et statiques
+
+Avec Octane, votre application reste en mémoire entre les requêtes. Faites attention à :
+- Ne pas utiliser de variables statiques qui accumulent des données
+- Toujours nettoyer les ressources (connexions, fichiers, etc.)
+- Utiliser les [Octane-safe patterns](https://laravel.com/docs/octane#managing-memory-leaks)
+
+### Tests
+
+Pour tester sans Octane :
+```bash
+php artisan serve
+```
+
+## 🔗 Ressources
+
+- [Documentation Laravel Octane](https://laravel.com/docs/octane)
+- [Documentation FrankenPHP](https://frankenphp.dev/)
+- [Guide Dotworld](https://tinyurl.com/guide-dev)
+
+## 👨‍💻 Auteur
+
+Maintenu par l'équipe Dotworld
+

--- a/stubs/stacks/Stack-php84-frankenphp/README.md
+++ b/stubs/stacks/Stack-php84-frankenphp/README.md
@@ -75,6 +75,16 @@ composer require laravel/octane
 php artisan octane:install --server=frankenphp
 ```
 
+### Vérification des extensions PHP
+
+Toutes les extensions sont pré-installées et configurées. Pour vérifier :
+
+```bash
+php -m | grep -E "(gd|intl|swoole|redis|memcached)"
+```
+
+Si vous voyez des warnings au démarrage sur `libavif`, `libcares` ou `libhashkit`, c'est que l'image doit être rebuildée avec les dernières modifications
+
 ### Configuration recommandée
 
 Dans votre fichier `config/octane.php` :

--- a/stubs/stacks/Stack-php84-frankenphp/customs/alias.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/alias.sh
@@ -1,0 +1,23 @@
+#############################################################
+#                                                           #
+#                     🛠️ FICHIER D'ALIAS 🛠️                  #
+#                                                           #
+# Ce fichier contient des alias personnalisés pour vos      #
+# sessions bash. Ajoutez vos alias souhaités ci-dessous.    #
+# Après avoir ajouté vos alias, redémarrez votre container  #
+# pour appliquer les changements.                           #
+#                                                           #
+# Exemple :                                                 #
+# alias ll='ls -la'                                         #
+#                                                           #
+#############################################################
+
+# Ajoutez vos alias ci-dessous
+
+
+alias phpunit="vendor/bin/phpunit"
+alias pest="vendor/bin/pest"
+alias pa="php artisan"
+alias octane="php artisan octane:start --server=frankenphp"
+alias octane-watch="php artisan octane:start --server=frankenphp --watch"
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/commands/artisan.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/commands/artisan.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Titre et description du script
+cmd="artisan"
+description="lancer l'artisan du projet Laravel courant"
+author="Thibaud WILLM <thibaud.willm@dotworld.ch"
+
+source $UTILS_DIR/functions.sh
+
+#si il n'y a pas d'argument en demander un avec gum
+if [ $# -eq 0 ]; then
+    php $WORKSPACE_DIR/artisan
+    cmd_artisan=$(gum input --placeholder "que veux tu lancer sur artisan ?")
+    php $WORKSPACE_DIR/artisan $cmd_artisan
+else
+    # Lancer l'artisan
+    php $WORKSPACE_DIR/artisan $*
+fi
+
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/commands/artisan.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/commands/artisan.sh
@@ -3,7 +3,7 @@
 # Titre et description du script
 cmd="artisan"
 description="lancer l'artisan du projet Laravel courant"
-author="Thibaud WILLM <thibaud.willm@dotworld.ch"
+author="Thibaud WILLM <thibaud.willm@dotworld.ch>"
 
 source $UTILS_DIR/functions.sh
 

--- a/stubs/stacks/Stack-php84-frankenphp/customs/commands/install.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/commands/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cmd="install"
+description="Initialiser le projet en lançant toutes les commandes."
+author="Gtko"
+
+source $UTILS_DIR/functions.sh
+
+# create .env
+print_message "Créer le .env a partir du .env.example" "📦"
+cp $WORKSPACE_DIR/.env.example $WORKSPACE_DIR/.env
+
+# Exécuter les commandes avec des barres de progression
+print_message "Installation des dépendances Composer" "📦"
+composer install
+
+# Install Laravel Octane with FrankenPHP
+print_message "Installation de Laravel Octane avec FrankenPHP" "🚀"
+php artisan octane:install --server=frankenphp
+
+print_message "Migration de la base de données et initialisation des données" "🗃️"
+php artisan migrate:fresh --seed
+
+print_message "Installation des dépendances NPM" "📦"
+npm install
+
+complete "Initialisation terminée !"
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/commands/octane.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/commands/octane.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Titre et description du script
+cmd="octane"
+description="Lancer Laravel Octane avec FrankenPHP (mode watch pour auto-reload)"
+author="Thibaud WILLM"
+
+source $UTILS_DIR/functions.sh
+
+# Vérifier si on veut le mode watch
+if [ "$1" == "--watch" ] || [ "$1" == "-w" ]; then
+    print_message "Lancement du serveur Laravel Octane avec FrankenPHP en mode watch" "🚀"
+    php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=80 --watch
+else
+    print_message "Lancement du serveur Laravel Octane avec FrankenPHP" "🚀"
+    php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=80
+fi
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/commands/run.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/commands/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+# Titre et description du script
+cmd="run"
+description="Lancement de la compilation des assets en mode developpeur."
+author="Gtko"
+
+source $UTILS_DIR/functions.sh
+
+cd $WORKSPACE_DIR
+print_message "Lancement de la compilation du frontend" "⚙️" $COLOR_GREEN
+npm run watch
+
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/commands/serve.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/commands/serve.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Titre et description du script
+cmd="Serve"
+description="Serveur Laravel Octane avec FrankenPHP !"
+author="Thibaud WILLM"
+
+source $UTILS_DIR/functions.sh
+
+# Exécuter les commandes avec des barres de progression
+print_message "Lancement du serveur Laravel Octane avec FrankenPHP" "🚀"
+php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=80
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/commands/xdebug.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/commands/xdebug.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+cmd="xdebug"
+description="Install, enable or disable xdebug"
+author="Thibaud WILLM"
+
+PHP_XDEBUG_INI="/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+
+source $UTILS_DIR/functions.sh
+
+# Function to install Xdebug
+install_xdebug() {
+    print_message "Installing Xdebug for FrankenPHP..."
+    
+    # Check if xdebug is already installed
+    if php -m | grep -q xdebug; then
+        print_message "Xdebug is already installed." "✅"
+    else
+        # Use install-php-extensions from FrankenPHP
+        print_message "Installing Xdebug extension..." "📦"
+        install-php-extensions xdebug
+    fi
+    
+    update_php_ini
+}
+
+# Function to enable Xdebug
+enable_xdebug() {
+    print_message "Enabling Xdebug..."
+    update_php_ini
+    print_message "Xdebug has been enabled." "✅"
+}
+
+# Function to disable Xdebug
+disable_xdebug() {
+    print_message "Disabling Xdebug..."
+    if [ -f "$PHP_XDEBUG_INI" ]; then
+        rm "$PHP_XDEBUG_INI"
+        print_message "Xdebug has been disabled." "✅"
+    else
+        print_message "Xdebug is not installed." "⚠️"
+    fi
+}
+
+update_php_ini() {
+  # Check if Xdebug is already configured
+  if [ -f "$PHP_XDEBUG_INI" ] && grep -q "^xdebug.idekey=dotworld" "$PHP_XDEBUG_INI"; then
+      print_message "Xdebug is already configured in $PHP_XDEBUG_INI" "✅"
+  else
+      # Create or overwrite Xdebug configuration
+      cat > "$PHP_XDEBUG_INI" <<EOF
+zend_extension=xdebug.so
+xdebug.mode=develop,debug
+xdebug.client_port=9003
+xdebug.start_with_request=yes
+xdebug.client_host=host.docker.internal
+xdebug.idekey=dotworld
+xdebug.log_level=0
+EOF
+      print_message "Xdebug configuration added to $PHP_XDEBUG_INI" "✅"
+  fi
+}
+
+
+install_xdebug
+
+
+exit 0
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/install.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/install.sh
@@ -1,0 +1,16 @@
+#############################################################
+#                                                           #
+#                   🛠️ FICHIER D'INSTALLATION 🛠️            #
+#                                                           #
+# Ce fichier contient des commandes pour configurer         #
+# l'environnement. Vous pouvez l'utiliser pour installer    #
+# et configurer des outils supplémentaires.                 #
+#                                                           #
+# Note: FrankenPHP et toutes les extensions PHP sont        #
+# déjà installées dans l'image de base.                     #
+#                                                           #
+#############################################################
+
+# Ajoutez vos commandes d'installation et de configuration ci-dessous
+
+

--- a/stubs/stacks/Stack-php84-frankenphp/customs/welcome.sh
+++ b/stubs/stacks/Stack-php84-frankenphp/customs/welcome.sh
@@ -1,0 +1,33 @@
+#############################################################
+#                                                           #
+#                     🎉 BIENVENUE 🎉                        #
+#                                                           #
+# Ce fichier est destiné à accueillir le dev                #
+# Vous trouverez ci-dessous des informations utiles pour    #
+# commencer à utiliser cet environnement.                   #
+#                                                           #
+# Profitez de votre expérience !                            #
+#                                                           #
+#############################################################
+
+# Ajoutez vos messages de bienvenue ci-dessous
+
+
+# Affiche le guide du développeur
+echo -e "\033[1;34mLe Guide Galactique du Développeur 2.0:\033[0m"
+echo -e "🔗 \033[1;33mhttps://tinyurl.com/guide-dev\033[0m - Ta bible chez dotworld"
+echo -e ""
+
+# Affiche le lien vers le README du projet
+echo -e "\033[1;34mLe Readme pour un developpeur au top !:\033[0m"
+echo -e "🔗 \033[1;33mREADME.md\033[0m - Ouvrir le fichier"
+
+echo -e ""
+
+# Message spécifique à FrankenPHP/Octane
+echo -e "\033[1;32m🚀 Stack PHP 8.4 avec FrankenPHP et Laravel Octane\033[0m"
+echo -e "\033[1;36mℹ️  Pour démarrer Octane avec FrankenPHP:\033[0m"
+echo -e "   • \033[1;33mphp artisan octane:start --server=frankenphp\033[0m"
+echo -e "   • Ou utilisez l'alias: \033[1;33moctane\033[0m ou \033[1;33moctane-watch\033[0m"
+echo -e ""
+

--- a/stubs/stacks/Stack-php84-frankenphp/describ
+++ b/stubs/stacks/Stack-php84-frankenphp/describ
@@ -1,0 +1,3 @@
+PHP 8.4 with FrankenPHP runtime, Node 22 base, MySQL 8 and Redis.
+Includes devcontainer, Docker Compose, and default ports: HTTP:80, WS:6001, DB:3306, Redis:6379.
+

--- a/stubs/stacks/Stack-php84-frankenphp/describ
+++ b/stubs/stacks/Stack-php84-frankenphp/describ
@@ -1,3 +1,4 @@
-PHP 8.4 with FrankenPHP runtime, Node 22 base, MySQL 8 and Redis.
-Includes devcontainer, Docker Compose, and default ports: HTTP:80, WS:6001, DB:3306, Redis:6379.
-
+PHP 8.4 with FrankenPHP runtime for Laravel Octane, Node 22 base, MySQL 8 and Redis.
+FrankenPHP provides ultra-fast performance with worker mode and HTTP/2/3 support.
+Includes devcontainer, Docker Compose, and default ports: HTTP:80/443, WS:6001, DB:3306, Redis:6379.
+Use 'php artisan octane:start --server=frankenphp' to launch your Laravel application.

--- a/stubs/stacks/Stack-php84-frankenphp/devcontainer.json
+++ b/stubs/stacks/Stack-php84-frankenphp/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "##APP_NAME##",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"dockerComposeFile": "docker/docker-compose.yml",
+	"service": "##APP_NAME##",
+	"runServices": [
+		"##APP_NAME##_mysql",
+		"##APP_NAME##_redis"
+	],
+	"workspaceFolder": "/workspaces/##APP_NAME##",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		80,
+		1025,
+		6001,
+		3306,
+		6379,
+		8025
+	],
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/zsh"
+	},
+	// Use 'postCreateCommand' to run commands after the container is created.[
+	"postCreateCommand": "sudo bash /workspaces/##APP_NAME##/.devcontainer/dotdev/utils/install_shell.sh",
+	"postAttachCommand": "",
+	//"postAttachCommand" : "cp .env.docker .env && composer install && php artisan migrate --seed && php artisan migrate --env=testing && php artisan shield:super-admin --user=1 && npm install && npm run dev",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"GitHub.copilot",
+				"onecentlin.laravel-extension-pack",
+				"vivaxy.vscode-conventional-commits",
+				"mhutchie.git-graph",
+				"ms-vscode-remote.remote-containers",
+				"GitHub.codespaces",
+				"GitHub.vscode-github-actions"
+			]
+		}
+	}
+}
+
+

--- a/stubs/stacks/Stack-php84-frankenphp/devcontainer.json
+++ b/stubs/stacks/Stack-php84-frankenphp/devcontainer.json
@@ -22,9 +22,9 @@
 		8025
 	],
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/zsh"
+        "terminal.integrated.defaultProfile.linux": "/bin/zsh"
 	},
-	// Use 'postCreateCommand' to run commands after the container is created.[
+	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "sudo bash /workspaces/##APP_NAME##/.devcontainer/dotdev/utils/install_shell.sh",
 	"postAttachCommand": "",
 	//"postAttachCommand" : "cp .env.docker .env && composer install && php artisan migrate --seed && php artisan migrate --env=testing && php artisan shield:super-admin --user=1 && npm install && npm run dev",

--- a/stubs/stacks/Stack-php84-frankenphp/docker/docker-compose.yml
+++ b/stubs/stacks/Stack-php84-frankenphp/docker/docker-compose.yml
@@ -1,0 +1,60 @@
+services:
+  ##APP_NAME##:
+    image: chdotworld/dotworld:php84-frankenphp
+    container_name: ##APP_NAME##
+    ports:
+      - '${APP_PORT:-80}:80'
+      - '${APP_WEBSOCKETS_PORT:-6001}:6001'
+    environment:
+      WWWUSER: '${WWWUSER}'
+      LARAVEL_SAIL: 1
+      SERVER_NAME: 'localhost, :80, :443'
+    volumes:
+      - '${APP_VOLUME}:/workspaces/${APP_NAME}'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+    networks:
+      - infrastructure
+    depends_on:
+      - ##APP_NAME##_redis
+      - ##APP_NAME##_mysql
+  ##APP_NAME##_mysql:
+    image: mysql/mysql-server:8.0
+    container_name: ##APP_NAME##_mysql
+    ports:
+      - '${FORWARD_DB_PORT:-3306}:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_DATABASE: '${DB_DATABASE}'
+      MYSQL_USER: '${DB_USERNAME}'
+      MYSQL_PASSWORD: '${DB_PASSWORD}'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    volumes:
+      - '##APP_NAME##_mysql_data:/var/lib/mysql'
+    networks:
+      - infrastructure
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}" ]
+      retries: 3
+      timeout: 5s
+  ##APP_NAME##_redis:
+    image: 'redis:alpine'
+    container_name: ##APP_NAME##_redis
+    ports:
+      - '${FORWARD_REDIS_PORT:-6379}:6379'
+    volumes:
+      - '##APP_NAME##_redis_data:/data'
+    networks:
+      - infrastructure
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+networks:
+  infrastructure:
+    driver: bridge
+
+volumes:
+  ##APP_NAME##_redis_data:
+    driver: local
+  ##APP_NAME##_mysql_data:
+    driver: local
+


### PR DESCRIPTION
Contributors : 
- @t-willm 

POLY-860
 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR introduces a comprehensive local development environment (devcontainer) for Laravel applications, leveraging FrankenPHP with Laravel Octane for high performance, alongside Node.js for frontend builds, MySQL, and Redis. It provides optimized Docker images and a set of helper scripts and configurations for a seamless development experience.

**Key Changes**
- Added Dockerfiles for Node.js 22 (Alpine) and PHP 8.4 with FrankenPHP (Alpine and Debian variants).
- Included `start-container` scripts, `php.ini` configurations, and `vscode-nopasswd` for Docker images.
- Introduced a new `Stack-php84-frankenphp` stub with a detailed `README.md` for setup and usage.
- Implemented custom shell aliases and commands (e.g., `install`, `artisan`, `octane`, `run`, `serve`, `xdebug`) to streamline common development tasks.
- Provided `devcontainer.json` and `docker-compose.yml` for easy integration with VS Code Dev Containers and service orchestration.

**Recommendations**
stable for release. This PR provides a robust and well-documented local development environment. For actual production deployment, consider hardening the Docker configurations and removing development-specific security allowances.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 877 (100.0%)  |
| Total Changes | 877         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>